### PR TITLE
Support scss files

### DIFF
--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/ResourceHelper.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/ResourceHelper.java
@@ -58,6 +58,14 @@ public class ResourceHelper {
 		IMG_EXTENSIONS.add("wbmp");
 	}
 
+	private final static Collection<String> CSS_EXTENSIONS;
+
+	static {
+		CSS_EXTENSIONS = new ArrayList<String>();
+		CSS_EXTENSIONS.add("css");
+		CSS_EXTENSIONS.add("scss");
+	}
+
 	/**
 	 * Returns the image file type of the given file.
 	 * 
@@ -114,7 +122,7 @@ public class ResourceHelper {
 		switch (resourceType) {
 		case css:
 		case js:
-			return resourceType.name().equalsIgnoreCase(extension);
+			return CSS_EXTENSIONS.contains(extension.toLowerCase());
 		case img:
 			return IMG_EXTENSIONS.contains(extension.toLowerCase());
 		}


### PR DESCRIPTION
In our liferay ide extension (to support bootstrap classes) we need to let the ICSSModel open scss files.  We have added the necessary contentType extensions in our plugin, but we need the webresources collector to not ignore scss files for CSS resourceType.
