### PR TITLE
Fix length of error marker for missing src file

### DIFF
--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/validation/MessageFactory.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/validation/MessageFactory.java
@@ -104,7 +104,7 @@ public class MessageFactory {
 
 	public void addMessage(IDOMAttr attr, WebResourcesFinderType type,
 			IFile file) {
-		String textContent = attr.getValue();
+		String textContent = attr.getValueRegionText();
 		int start = attr.getValueRegionStartOffset();
 		addMessage(attr, start, textContent, type, file);
 	}


### PR DESCRIPTION
The length was not calculated properly. Length of attr.getValue() was
taken while it should be the length of attr.getValueRegionText(). The
difference comes when the attribute value is wrapped in quotes.

The problem is especially visible when using the dark theme.
![image](https://cloud.githubusercontent.com/assets/468091/5073611/c435b426-6e8b-11e4-988c-e28aa8ff9a18.png)
