### PR TITLE
Fixes #37 - Mark folders as web root folders

### DIFF
--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/WebResourcesCorePlugin.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/WebResourcesCorePlugin.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2013-2014 Angelo ZERR.
+ *  Copyright (c) 2013-2015 Angelo ZERR and others.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Kaloyan Raev <kaloyan.r@zend.com> - #37 Mark folders as web root folders
  */
 package org.eclipse.wst.html.webresources.core;
 
@@ -89,6 +90,15 @@ public class WebResourcesCorePlugin extends Plugin {
 	 */
 	public static WebResourcesCorePlugin getDefault() {
 		return plugin;
+	}
+	
+	/**
+	 * Logs the given <code>Throwable</code>.
+	 * 
+	 * @param t the <code>Throwable</code>
+	 */
+	public static void log(Throwable t) {
+		plugin.getLog().log(new Status(IStatus.ERROR, PLUGIN_ID, t.getMessage(), t));
 	}
 
 	/**

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/WebRootFolders.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/WebRootFolders.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright (c) 2015 Zend Technologies Ltd.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Kaloyan Raev <kaloyan.r@zend.com> - initial API and implementation
+ */
+package org.eclipse.wst.html.webresources.core;
+
+import java.util.Arrays;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.QualifiedName;
+
+/**
+ * Helper class to store web root folders configuration in IProject.
+ */
+public class WebRootFolders {
+
+	public static final QualifiedName PROPERTY_KEY = new QualifiedName(
+			WebResourcesCorePlugin.PLUGIN_ID, WebRootFolders.class.getName());
+
+	public static String[] getWebRootFolders(IProject project) {
+		String value = null;
+
+		try {
+			value = project.getPersistentProperty(PROPERTY_KEY);
+		} catch (CoreException e) {
+			WebResourcesCorePlugin.log(e);
+		}
+		
+		if (value == null) {
+			return new String[0];
+		}
+		
+		value = value.substring(1, value.length() - 1);
+		
+		if (value.isEmpty()) {
+			return new String[0];
+		}
+
+		return value.split(",( )*");
+	}
+
+	public static void setWebRootFolders(IProject project, String[] roots) {
+		String value = Arrays.toString(roots);
+		
+		try {
+			project.setPersistentProperty(PROPERTY_KEY, value);
+		} catch (CoreException e) {
+			WebResourcesCorePlugin.log(e);
+		}
+	}
+
+}

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/providers/DefaultURIResolver.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/providers/DefaultURIResolver.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2013-2014 Angelo ZERR.
+ *  Copyright (c) 2013-2015 Angelo ZERR and others.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,13 +7,17 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Kaloyan Raev <kaloyan.r@zend.com> - #37 Mark folders as web root folders
  */
 package org.eclipse.wst.html.webresources.core.providers;
 
+import org.eclipse.core.resources.IContainer;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
+import org.eclipse.wst.html.webresources.core.WebRootFolders;
 
 public class DefaultURIResolver implements IURIResolver {
 
@@ -31,6 +35,15 @@ public class DefaultURIResolver implements IURIResolver {
 		if (uri.startsWith("http")) {
 			// TODO : validate http web resources
 			return true;
+		} else if (uri.startsWith("/")) {
+			IProject project = root.getProject();
+			String[] webRootFolders = WebRootFolders.getWebRootFolders(project);
+			for (String webRootFolder : webRootFolders) {
+				IResource resource = project.findMember(webRootFolder);
+				if (resource instanceof IContainer && ((IContainer) resource).exists(new Path(uri))) {
+					return true;
+				}
+			}
 		}
 		return root.getParent().exists(new Path(uri));
 	}

--- a/org.eclipse.a.wst.html.webresources.ui/plugin.properties
+++ b/org.eclipse.a.wst.html.webresources.ui/plugin.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2013 Angelo Zerr and others.
+# Copyright (c) 2013-2015 Angelo Zerr and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
 #
 # Contributors:
 #     Angelo Zerr <angelo.zerr@gmail.com> - Initial API and implementation 
+#     Kaloyan Raev <kaloyan.r@zend.com> - #37 Mark folders as web root folders
 ###############################################################################
 pluginProvider=Angelo ZERR
 pluginName=WTP HTML - Web Resources - UI
@@ -22,3 +23,4 @@ WebResources_CSS=CSS
 WebResources_Property_main=Web Resources
 WebResources_Property_validation=Validation
 WebResources_Property_CSS=CSS
+WebResources_Property_roots=Web Root Folders

--- a/org.eclipse.a.wst.html.webresources.ui/plugin.xml
+++ b/org.eclipse.a.wst.html.webresources.ui/plugin.xml
@@ -2,7 +2,7 @@
 <?eclipse version="3.0"?>
 <!--
 ###############################################################################
-# Copyright (c) 2013 Angelo Zerr and others.
+# Copyright (c) 2013-2015 Angelo Zerr and others.
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
 # which accompanies this distribution, and is available at
@@ -10,6 +10,7 @@
 #
 # Contributors:
 #     Angelo Zerr <angelo.zerr@gmail.com> - Initial API and implementation 
+#     Kaloyan Raev <kaloyan.r@zend.com> - #37 Mark folders as web root folders
 ###############################################################################
  -->
 <plugin>
@@ -117,7 +118,17 @@
 				<adapt type="org.eclipse.core.resources.IProject">					
 				</adapt>
 			</enabledWhen>
-		</page>				
+		</page>
+		<page
+			name="%WebResources_Property_roots"
+			class="org.eclipse.wst.html.webresources.internal.ui.preferences.WebResourcesRootFoldersPropertyPage"
+			id="org.eclipse.wst.html.webresources.ui.propertyPage.project.roots"
+			category="org.eclipse.wst.html.webresources.ui.propertyPage.project.validation">
+			<enabledWhen>
+				<adapt type="org.eclipse.core.resources.IProject">
+				</adapt>
+			</enabledWhen>
+		</page>
 	</extension>
 
 	<!-- Quick fix -->

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/WebResourcesUIMessages.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/WebResourcesUIMessages.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2013-2014 Angelo ZERR.
+ *  Copyright (c) 2013-2015 Angelo ZERR.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Kaloyan Raev <kaloyan.r@zend.com> - #37 Mark folders as web root folders
  */
 package org.eclipse.wst.html.webresources.internal.ui;
 
@@ -46,6 +47,10 @@ public final class WebResourcesUIMessages extends NLS {
 
 	// CSS preferences
 	public static String CSSPreferencesPage_searchInAllCSSFiles_label;
+	
+	// Web Root Folders Property Page
+	public static String WebRootFoldersPropertyPage_description;
+	public static String WebRootFoldersPropertyPage_select;
 	
 	// Quick fix
 	public static String CreateFileCompletionProposal_errorTitle;

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/WebResourcesUIMessages.properties
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/WebResourcesUIMessages.properties
@@ -20,6 +20,10 @@ WebResourcesValidationPreferencePage_CSS_ID_UNKNOWN=Unknown CSS ID:
 # CSS Preferences
 CSSPreferencesPage_searchInAllCSSFiles_label=Search CSS id and class in all CSS files (if no link)?
 
+# Web Root Folders Property Page
+WebRootFoldersPropertyPage_description=Web root folders are those folders in the project, which content will be deployed in the web root of the web server. The below settings are just a hint for the web resources validation and not a configuration for an eventual deployment.
+WebRootFoldersPropertyPage_select=Select &web root folders:
+
 # Quick fix
 CreateFileCompletionProposal_errorTitle=New file error.
 CreateFileCompletionProposal_errorMessage=Error while creating file {0}

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/WebResourcesUIPlugin.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/WebResourcesUIPlugin.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright (c) 2013-2014 Angelo ZERR.
+ *  Copyright (c) 2013-2015 Angelo ZERR.
  *  All rights reserved. This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License v1.0
  *  which accompanies this distribution, and is available at
@@ -7,9 +7,12 @@
  *
  *  Contributors:
  *  Angelo Zerr <angelo.zerr@gmail.com> - initial API and implementation
+ *  Kaloyan Raev <kaloyan.r@zend.com> - #37 Mark folders as web root folders
  */
 package org.eclipse.wst.html.webresources.internal.ui;
 
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
@@ -65,6 +68,15 @@ public class WebResourcesUIPlugin extends AbstractUIPlugin {
 	 */
 	public static WebResourcesUIPlugin getDefault() {
 		return plugin;
+	}
+	
+	/**
+	 * Logs the given <code>Throwable</code>.
+	 * 
+	 * @param t the <code>Throwable</code>
+	 */
+	public static void log(Throwable t) {
+		plugin.getLog().log(new Status(IStatus.ERROR, PLUGIN_ID, t.getMessage(), t));
 	}
 
 	public static IWorkbenchWindow getActiveWorkbenchWindow() {

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/preferences/WebResourcesRootFoldersPropertyPage.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/preferences/WebResourcesRootFoldersPropertyPage.java
@@ -1,0 +1,186 @@
+/**
+ *  Copyright (c) 2015 Zend Technologies Ltd.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *  Kaloyan Raev <kaloyan.r@zend.com> - initial API and implementation
+ */
+package org.eclipse.wst.html.webresources.internal.ui.preferences;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.jface.viewers.CheckboxTreeViewer;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.LabelProvider;
+import org.eclipse.jface.viewers.Viewer;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.ui.ISharedImages;
+import org.eclipse.ui.IWorkbenchPropertyPage;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.dialogs.PropertyPage;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.wst.html.webresources.core.WebRootFolders;
+import org.eclipse.wst.html.webresources.internal.ui.WebResourcesUIMessages;
+import org.eclipse.wst.html.webresources.internal.ui.WebResourcesUIPlugin;
+
+/**
+ * Property page for Web Root folders.
+ */
+public class WebResourcesRootFoldersPropertyPage extends PropertyPage implements
+		IWorkbenchPropertyPage {
+	
+	private CheckboxTreeViewer tree;
+
+	public WebResourcesRootFoldersPropertyPage() {
+		setDescription(WebResourcesUIMessages.WebRootFoldersPropertyPage_description);
+	}
+
+	@Override
+	protected Control createContents(Composite parent) {
+		Composite composite = new Composite(parent, SWT.NONE);
+		composite.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+		GridLayout layout = new GridLayout();
+		layout.marginHeight = layout.marginWidth = 0;
+		composite.setLayout(layout);
+		
+		Label label = new Label(composite, SWT.NONE);
+		label.setText(WebResourcesUIMessages.WebRootFoldersPropertyPage_select);
+		
+		tree = new CheckboxTreeViewer(composite, SWT.BORDER);
+		tree.getTree().setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+		tree.setContentProvider(new ITreeContentProvider() {
+			@Override
+			public Object[] getElements(Object inputElement) {
+				return new Object[] { getProject() };
+			}
+			
+			@Override
+			public Object[] getChildren(Object parentElement) {
+				IContainer container = (IContainer) parentElement;
+				List<IResource> children = new ArrayList<IResource>();
+				
+				if (container.isAccessible()) {
+					try {
+						for (IResource resource : container.members()) {
+							if (resource instanceof IContainer) {
+								children.add(resource);
+							}
+						}
+					} catch (CoreException e) {
+						WebResourcesUIPlugin.log(e);
+					}
+				}
+				
+				return children.toArray();
+			}
+			
+			@Override
+			public Object getParent(Object element) {
+				return ((IResource) element).getParent();
+			}
+			
+			@Override
+			public boolean hasChildren(Object element) {
+				IContainer container = (IContainer) element;
+				
+				if (container.isAccessible()) {
+					try {
+						for (IResource resource : container.members()) {
+							if (resource instanceof IContainer) {
+								return true;
+							}
+						}
+					} catch (CoreException e) {
+						WebResourcesUIPlugin.log(e);
+					}
+				}
+				
+				return false;
+			}
+			
+			@Override
+			public void inputChanged(Viewer viewer, Object oldInput, Object newInput) {
+			}
+			
+			@Override
+			public void dispose() {
+			}
+		});
+		tree.setLabelProvider(new LabelProvider() {
+			@Override
+			public String getText(Object element) {
+				return ((IResource) element).getName();
+			}
+
+			@Override
+			public Image getImage(Object element) {
+				String id;
+				
+				if (element instanceof IProject) {
+					IProject project = ((IProject) element);
+					if (project.isOpen()) {
+						id = IDE.SharedImages.IMG_OBJ_PROJECT;
+					} else {
+						id = IDE.SharedImages.IMG_OBJ_PROJECT_CLOSED;
+					}
+				} else {
+					id = ISharedImages.IMG_OBJ_FOLDER;
+				}
+				
+				return PlatformUI.getWorkbench().getSharedImages().getImage(id);
+			}
+		});
+		tree.setAutoExpandLevel(2);
+		tree.setInput(new Object[0]);
+		
+		String[] roots = WebRootFolders.getWebRootFolders(getProject());
+		for (String root : roots) {
+			IResource resource = getProject().findMember(root);
+			tree.setChecked(resource, true);
+			tree.reveal(resource);
+		}
+		
+		return composite;
+	}
+	
+	private IProject getProject() {
+		return (IProject) getElement().getAdapter(IProject.class);
+	}
+
+	@Override
+	public boolean performOk() {
+		List<String> roots = new ArrayList<String>();
+		
+		for (Object element : tree.getCheckedElements()) {
+			IPath path = ((IResource) element).getFullPath().removeFirstSegments(1);
+			roots.add('/' + path.toString());
+		}
+		
+		WebRootFolders.setWebRootFolders(getProject(), roots.toArray(new String[roots.size()]));
+		
+		return super.performOk();
+	}
+
+	@Override
+	protected void performDefaults() {
+		tree.setSubtreeChecked(getProject(), false);
+		
+		super.performDefaults();
+	}
+	
+}


### PR DESCRIPTION
New Web Resources > Validation > Web Root Folders property page is
added. It allows zero or more folders from the project to be selected as
web root folders. The settings are stored as persistent property in the
IProject.

The DefaultURIResolver reads the persistent property to find out if any
web root folders are selected for the current project. If yes, then the
existence of files with path containing a leading / are validated
against the web root folders.