### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/CSSClassNameFinder.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/CSSClassNameFinder.java
@@ -19,6 +19,8 @@ import org.eclipse.jface.text.IDocument;
  */
 public class CSSClassNameFinder {
 
+	private CSSClassNameFinder() {}
+
 	public static WebResourceRegion findClassName(IDocument document,
 			int offset, int startOffset, int endOffset) {
 

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/WebRootFolders.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/WebRootFolders.java
@@ -24,6 +24,8 @@ public class WebRootFolders {
 	public static final QualifiedName PROPERTY_KEY = new QualifiedName(
 			WebResourcesCorePlugin.PLUGIN_ID, WebRootFolders.class.getName());
 
+	private WebRootFolders() {}
+
 	public static String[] getWebRootFolders(IProject project) {
 		String value = null;
 

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/preferences/WebResourcesCorePreferenceNames.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/preferences/WebResourcesCorePreferenceNames.java
@@ -33,6 +33,5 @@ public class WebResourcesCorePreferenceNames {
 	public static final String CSS_USE_PROJECT_SETTINGS = "css-use-project-settings";//$NON-NLS-1$
 	public static final String SEARCH_IN_ALL_CSS_FILES_IF_NO_LINKS = "search-in-all-css-files-if-no-links"; //$NON-NLS-1$
 
-
-	
+	private WebResourcesCorePreferenceNames() {}
 }

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/DOMHelper.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/DOMHelper.java
@@ -45,6 +45,8 @@ import org.w3c.dom.NamedNodeMap;
  */
 public class DOMHelper {
 
+	private DOMHelper() {}
+
 	/**
 	 * Returns the "@class", "@id", "script/@src", "link/@href" or , "img/@src"
 	 * attribute value region from the given document region and position and

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/ResourceHelper.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/ResourceHelper.java
@@ -46,6 +46,8 @@ public class ResourceHelper {
 		CSS_EXTENSIONS.add("scss");
 	}
 
+	private ResourceHelper() {}
+
 	/**
 	 * Returns the web resource type of the given resource and null otherwise.
 	 * 

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/URIHelper.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/URIHelper.java
@@ -28,6 +28,8 @@ public class URIHelper {
 
 	private static final String DOUBLE_SLASH = "//";
 
+	private URIHelper() {}
+
 	/**
 	 * Returns true if the given uri is a data URI scheme and false otherwise.
 	 * 

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/utils/EditorUtils.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/utils/EditorUtils.java
@@ -35,6 +35,8 @@ import org.eclipse.wst.html.webresources.internal.ui.WebResourcesUIPlugin;
  */
 public class EditorUtils {
 
+	private EditorUtils() {}
+
 	public static IEditorPart openInEditor(IFile file, int start, int length,
 			boolean activate) {
 		IEditorPart editor = null;

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/utils/HTMLWebResourcesPrinter.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/utils/HTMLWebResourcesPrinter.java
@@ -45,6 +45,8 @@ public class HTMLWebResourcesPrinter {
 	 */
 	private static String fgStyleSheet;
 
+	private HTMLWebResourcesPrinter() {}
+
 	// ---------------------------- HTML info for Image
 
 	/**

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/utils/ResourceUIHelper.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/utils/ResourceUIHelper.java
@@ -37,6 +37,8 @@ public class ResourceUIHelper {
 		}
 	};
 
+	private ResourceUIHelper() {}
+
 	/**
 	 * Returns the image file type of the given file.
 	 * 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
This pull request removes technical debt of 270 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava