### PR TITLE
squid:SwitchLastCaseIsDefaultCheck - switch statements should end with a default clause

### DIFF
--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/AbstractCSSClassNameOrIdTraverser.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/AbstractCSSClassNameOrIdTraverser.java
@@ -185,6 +185,8 @@ public abstract class AbstractCSSClassNameOrIdTraverser extends
 			return DOMHelper.getModel((IFile) resource);
 		case FILESYSTEM:
 			return DOMHelper.getModel((File) resource);
+		default:
+			break;
 		}
 		return null;
 	}

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/ResourceHelper.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/ResourceHelper.java
@@ -132,6 +132,8 @@ public class ResourceHelper {
 			return resourceType.name().equalsIgnoreCase(extension);
 		case img:
 			return IMG_EXTENSIONS.contains(extension.toLowerCase());
+		default:
+			break;
 		}
 		return false;
 	}

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/validation/MessageFactory.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/validation/MessageFactory.java
@@ -73,6 +73,8 @@ public class MessageFactory {
 			return WebResourcesCorePreferenceNames.FILE_CSS_UNKNOWN;
 		case IMG_SRC:
 			return WebResourcesCorePreferenceNames.FILE_IMG_UNKNOWN;
+		default:
+			break;
 		}
 		return null;
 	}
@@ -169,6 +171,8 @@ public class MessageFactory {
 		case IMG_SRC:
 			return externalURL ? WebResourcesValidationMessages.Validation_URL_IMG_UNDEFINED
 					: WebResourcesValidationMessages.Validation_FILE_IMG_UNDEFINED;
+		default:
+			break;
 		}
 		return null;
 	}

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/validation/WebResourcesValidator.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/validation/WebResourcesValidator.java
@@ -394,6 +394,8 @@ public class WebResourcesValidator extends AbstractValidator implements
 					validateImage(documentRegion, reporter, model, file,
 							factory, attrValueRegion, finderType);
 					break;
+				default:
+					break;
 				}
 			}
 		}
@@ -439,6 +441,8 @@ public class WebResourcesValidator extends AbstractValidator implements
 							attr, file, hoverRegion, factory);
 					cssClassNameTraverser.process(monitor);
 
+					break;
+				default:
 					break;
 				}
 			}

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/providers/WebResourcesProxyVisitor.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/providers/WebResourcesProxyVisitor.java
@@ -74,6 +74,8 @@ public class WebResourcesProxyVisitor implements IResourceProxyVisitor {
 					stop = true;
 				}
 			}
+		default:
+			break;
 		}
 		return !stop;
 	}

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/search/WebResourcesIndexManager.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/search/WebResourcesIndexManager.java
@@ -66,6 +66,8 @@ public class WebResourcesIndexManager extends AbstractIndexManager {
 			return !name.equals(BIN_FOLDER) && !name.startsWith(".");
 		case IResource.FILE:
 			return ResourceHelper.isWebResource(name);
+		default:
+			break;
 		}
 		return false;
 	}
@@ -94,6 +96,8 @@ public class WebResourcesIndexManager extends AbstractIndexManager {
 				case AbstractIndexManager.ACTION_REMOVE:
 					// remove (css, img or js) file
 					configuration.removeWebResource(container, resourceType);
+					break;
+				default:
 					break;
 				}
 			} catch (CoreException e) {

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/contentassist/WebResourcesCompletionProposalComputer.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/contentassist/WebResourcesCompletionProposalComputer.java
@@ -75,6 +75,8 @@ public class WebResourcesCompletionProposalComputer extends
 				processFilesCompletion(contentAssistRequest, context,
 						attrValue, attrValueRegion, monitor);
 				break;
+			default:
+				break;
 			}
 
 		}

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/hover/WebResourcesHoverProcessor.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/hover/WebResourcesHoverProcessor.java
@@ -100,6 +100,8 @@ public class WebResourcesHoverProcessor extends AbstractHoverProcessor
 			case IMG_SRC:
 				return DOMHelper.getAttrValueRegion(attrValueRegion,
 						documentRegion, textViewer.getDocument(), offset);
+			default:
+				break;
 			}
 		}
 		return null;

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/hyperlink/CSSHyperlink.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/hyperlink/CSSHyperlink.java
@@ -95,6 +95,8 @@ public class CSSHyperlink implements IHyperlink {
 				}
 			}
 			break;
+		default:
+			break;
 		}
 	}
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:SwitchLastCaseIsDefaultCheck - switch statements should end with a default clause.
This pull request removes technical debt of 60 minutes.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:SwitchLastCaseIsDefaultCheck
Please let me know if you have any questions.
George Kankava