### PR TITLE
Multiple code improvements - squid:S1213, squid:S1192, squid:S1905

### DIFF
--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/WebResourcesFinderTypeProviderManager.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/WebResourcesFinderTypeProviderManager.java
@@ -32,6 +32,8 @@ import org.eclipse.wst.sse.core.internal.provisional.text.IStructuredDocumentReg
 public class WebResourcesFinderTypeProviderManager implements
 		IRegistryChangeListener {
 
+	private static final String CLASS = "class";
+
 	private static final String EXTENSION_WEB_RESOURCES_FINDER_TYPE_PROVIDERS = "webResourcesFinderTypeProviders";
 
 	private static final WebResourcesFinderTypeProviderManager INSTANCE = new WebResourcesFinderTypeProviderManager();
@@ -40,12 +42,12 @@ public class WebResourcesFinderTypeProviderManager implements
 
 	private boolean registryListenerIntialized;
 
-	public static WebResourcesFinderTypeProviderManager getManager() {
-		return INSTANCE;
-	}
-
 	public WebResourcesFinderTypeProviderManager() {
 		this.registryListenerIntialized = false;
+	}
+
+	public static WebResourcesFinderTypeProviderManager getManager() {
+		return INSTANCE;
 	}
 
 	@Override
@@ -102,16 +104,16 @@ public class WebResourcesFinderTypeProviderManager implements
 		for (IConfigurationElement ce : cf) {
 			try {
 				list.add((IWebResourcesFinderTypeProvider) ce
-						.createExecutableExtension("class"));
+						.createExecutableExtension(CLASS));
 				Trace.trace(
 						Trace.EXTENSION_POINT,
 						"  Loaded console connectors: "
-								+ ce.getAttribute("class"));
+								+ ce.getAttribute(CLASS));
 			} catch (Throwable t) {
 				Trace.trace(
 						Trace.SEVERE,
 						"  Could not load console connectors: "
-								+ ce.getAttribute("class"), t);
+								+ ce.getAttribute(CLASS), t);
 			}
 		}
 	}

--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/search/WebResourcesIndexManager.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/internal/core/search/WebResourcesIndexManager.java
@@ -45,14 +45,14 @@ public class WebResourcesIndexManager extends AbstractIndexManager {
 
 	private static final WebResourcesIndexManager INSTANCE = new WebResourcesIndexManager();
 
-	public static WebResourcesIndexManager getDefault() {
-		return INSTANCE;
-	}
-
 	private IPath fWorkingLocation;
 
 	protected WebResourcesIndexManager() {
 		super(WebResourcesCoreMessages.WebResourcesIndexManager);
+	}
+
+	public static WebResourcesIndexManager getDefault() {
+		return INSTANCE;
 	}
 
 	@Override

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/hover/WebResourcesBrowserInformationControlInput.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/hover/WebResourcesBrowserInformationControlInput.java
@@ -68,7 +68,7 @@ public class WebResourcesBrowserInformationControlInput extends
 	 */
 	@Override
 	public Object getInputElement() {
-		return (Object) fHtml;
+		return fHtml;
 	}
 
 	/*

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/preferences/WebResourcesValidationPreferencePage.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/preferences/WebResourcesValidationPreferencePage.java
@@ -53,6 +53,10 @@ public class WebResourcesValidationPreferencePage extends
 
 	private static final String SETTINGS_SECTION_NAME = "WebResourcesValidationSeverities";//$NON-NLS-1$
 
+	private IPreferencesService fPreferencesService = null;
+	private PixelConverter fPixelConverter;
+	private Button validateExternalURL;
+
 	private class BooleanData {
 		private String fKey;
 		private boolean fValue;
@@ -94,10 +98,6 @@ public class WebResourcesValidationPreferencePage extends
 		super();
 		fPreferencesService = Platform.getPreferencesService();
 	}
-
-	private IPreferencesService fPreferencesService = null;
-	private PixelConverter fPixelConverter;
-	private Button validateExternalURL;
 
 	protected Control createCommonContents(Composite parent) {
 		final Composite page = new Composite(parent, SWT.NULL);

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/text/correction/WebResourceQuickFixProcessor.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/text/correction/WebResourceQuickFixProcessor.java
@@ -138,7 +138,7 @@ public class WebResourceQuickFixProcessor implements IQuickAssistProcessor {
 		if (proposals.isEmpty())
 			return null;
 
-		return (ICompletionProposal[]) proposals
+		return proposals
 				.toArray(new ICompletionProposal[proposals.size()]);
 
 	}

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/utils/HTMLWebResourcesPrinter.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/utils/HTMLWebResourcesPrinter.java
@@ -40,6 +40,9 @@ import org.osgi.framework.Bundle;
  */
 public class HTMLWebResourcesPrinter {
 
+	private static final String HR = "<hr />";
+	private static final String P_NBSP_P = "<p>&nbsp;</p>";
+
 	/**
 	 * Style sheets content.
 	 */
@@ -59,14 +62,14 @@ public class HTMLWebResourcesPrinter {
 		StringBuffer buffer = new StringBuffer();
 		ImageDescriptor descriptor = null;
 		startPage(buffer, "", descriptor);
-		buffer.append("<hr />");
+		buffer.append(HR);
 		// resource is an image, display it.
 		buffer.append("<img src=\"");
 		buffer.append(data);
 		buffer.append("\" />");
 		long length = 1;
 		for (int i = 0; i < length; i++) {
-			buffer.append("<p>&nbsp;</p>");
+			buffer.append(P_NBSP_P);
 		}
 		endPage(buffer);
 		return buffer.toString();
@@ -87,7 +90,7 @@ public class HTMLWebResourcesPrinter {
 		ImageDescriptor descriptor = ResourceUIHelper
 				.getFileTypeImageDescriptor(resource);
 		startPage(buffer, getTitle(resource), descriptor);
-		buffer.append("<hr />");
+		buffer.append(HR);
 		if (type == WebResourceType.img) {
 			// resource is an image, display it.
 			buffer.append("<img src=\"file:/");
@@ -98,7 +101,7 @@ public class HTMLWebResourcesPrinter {
 			long length = Math
 					.round((double) (imageHeight != null ? imageHeight : 16) / 16);
 			for (int i = 0; i < length; i++) {
-				buffer.append("<p>&nbsp;</p>");
+				buffer.append(P_NBSP_P);
 			}
 		}
 		endPage(buffer);
@@ -132,11 +135,11 @@ public class HTMLWebResourcesPrinter {
 		StringBuffer buffer = new StringBuffer();
 		ImageDescriptor descriptor = getImageDescriptor(type);
 		startPage(buffer, getTitle(rule, node), descriptor);
-		buffer.append("<hr />");
+		buffer.append(HR);
 		buffer.append("<pre>");
 		buffer.append(rule.getCssText());
 		buffer.append("</pre>");
-		buffer.append("<p>&nbsp;</p>");
+		buffer.append(P_NBSP_P);
 		endPage(buffer);
 		return buffer.toString();
 	}


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1192 - String literals should not be duplicated.
squid:S1905 - Redundant casts should not be used.
This pull request removes 64 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S1905
Please let me know if you have any questions.
George Kankava