### PR TITLE
squid:S2696 - Instance methods should not write to 'static' fields

### DIFF
--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/WebResourcesCorePlugin.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/WebResourcesCorePlugin.java
@@ -58,7 +58,7 @@ public class WebResourcesCorePlugin extends Plugin {
 	 */
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
-		plugin = this;
+		setPlugin(this);
 		this.fPluginInitializerJob = new PluginInitializerJob();
 		// schedule delayed initialization
 		this.fPluginInitializerJob.schedule(2000);
@@ -76,7 +76,7 @@ public class WebResourcesCorePlugin extends Plugin {
 		WebResourcesFinderTypeProviderManager.getManager().destroy();
 		// stop any indexing
 		WebResourcesIndexManager.getDefault().stop();
-		plugin = null;
+		setPlugin(null);
 		super.stop(context);
 	}
 
@@ -231,5 +231,9 @@ public class WebResourcesCorePlugin extends Plugin {
 		public void saving(ISaveContext context) throws CoreException {
 			context.needDelta();
 		}
+	}
+
+	public static void setPlugin(WebResourcesCorePlugin plugin) {
+		WebResourcesCorePlugin.plugin = plugin;
 	}
 }

--- a/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/WebResourcesUIPlugin.java
+++ b/org.eclipse.a.wst.html.webresources.ui/src/org/eclipse/wst/html/webresources/internal/ui/WebResourcesUIPlugin.java
@@ -44,7 +44,7 @@ public class WebResourcesUIPlugin extends AbstractUIPlugin {
 	 */
 	public void start(BundleContext context) throws Exception {
 		super.start(context);
-		plugin = this;
+		setPlugin(this);
 	}
 
 	/*
@@ -56,7 +56,7 @@ public class WebResourcesUIPlugin extends AbstractUIPlugin {
 	 */
 	public void stop(BundleContext context) throws Exception {
 		ImageResource.dispose();
-		plugin = null;
+		setPlugin(null);
 		super.stop(context);
 	}
 
@@ -95,6 +95,10 @@ public class WebResourcesUIPlugin extends AbstractUIPlugin {
 	 */
 	public static IWorkbenchPage getActivePage() {
 		return getActiveWorkbenchWindow().getActivePage();
+	}
+
+	public static void setPlugin(WebResourcesUIPlugin plugin) {
+		WebResourcesUIPlugin.plugin = plugin;
 	}
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2696 - Instance methods should not write to 'static' fields.
This pull request removes technical debt of 1 hour.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2696
Please let me know if you have any questions.
George Kankava