### PR TITLE
squid:S2583 - Conditions should not unconditionally evaluate to 'TRUE' or to 'FALSE'

### DIFF
--- a/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/DOMHelper.java
+++ b/org.eclipse.a.wst.html.webresources.core/src/org/eclipse/wst/html/webresources/core/utils/DOMHelper.java
@@ -274,9 +274,6 @@ public class DOMHelper {
 		} catch (Exception e) {
 
 		}
-		if (model != null) {
-			model.releaseFromRead();
-		}
 		return null;
 	}
 
@@ -293,9 +290,6 @@ public class DOMHelper {
 			return (ICSSModel) model;
 		} catch (Exception e) {
 
-		}
-		if (model != null) {
-			model.releaseFromRead();
 		}
 		return null;
 	}
@@ -375,13 +369,11 @@ public class DOMHelper {
 				return (IDOMNode) node;
 			}
 
-			if (model != null) {
-				int lastOffset = offset;
-				node = model.getIndexedRegion(offset);
-				while (node == null && lastOffset >= 0) {
-					lastOffset--;
-					node = model.getIndexedRegion(lastOffset);
-				}
+			int lastOffset = offset;
+			node = model.getIndexedRegion(offset);
+			while (node == null && lastOffset >= 0) {
+				lastOffset--;
+				node = model.getIndexedRegion(lastOffset);
 			}
 		}
 		return (IDOMNode) node;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2583 - Conditions should not unconditionally evaluate to 'TRUE' or to 'FALSE'.
This pull request removes 45 minutes of technical debt.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S2583
Please let me know if you have any questions.
George Kankava